### PR TITLE
Fix default EventMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ export interface EventMap extends BaseEventMap {
   'theme:change': 'light' | 'dark';
   'modal:close': void;
 }
+// `BaseEventMap` is intentionally empty so you can define your own events.
 ```
 
 ### 2. Set up the provider
@@ -278,6 +279,7 @@ export interface EventMap extends BaseEventMap {
   'cart:remove': { productId: string };
   'cart:clear': void;
 }
+// `BaseEventMap` has no predefined events.
 ```
 
 ### Using with Multiple Event Buses

--- a/src/Eventizer.ts
+++ b/src/Eventizer.ts
@@ -2,15 +2,7 @@
  * EventMap interface to be extended by users of the library.
  * Keys are event names and values are payload types.
  */
-export interface EventMap {
-  // Example events:
-  'user:login': { username: string };
-  'user:logout': void;
-  // Test events:
-  'test:event': string;
-  'test:counter': number;
-  // Extend with more events as needed.
-}
+export interface EventMap {}
 
 /**
  * Core event bus class that manages subscriptions and event emissions.


### PR DESCRIPTION
## Summary
- remove sample events from `EventMap`
- clarify in README that `EventMap` is empty for user events

## Testing
- `npm test` *(fails: jest not found)*